### PR TITLE
Spectrogram of uploaded file shows in our dashboard

### DIFF
--- a/Getting_spectrogram.py
+++ b/Getting_spectrogram.py
@@ -1,0 +1,76 @@
+
+import numpy as np
+import pandas as pd 
+
+import librosa
+import librosa.display
+from sklearn.preprocessing import normalize
+from keras.models import load_model
+
+# buff depedencies 
+import os
+import io
+from cv2 import cv2 
+import matplotlib.pyplot as plt
+
+# URL 
+import cloudinary
+import cloudinary.uploader
+import soundfile as sf
+from six.moves.urllib.request import urlopen
+
+import tensorflow as tf
+
+
+
+# create a functions to get pitch and instrument spectrogram
+def get_spect_pitch(url):
+    '''This function gets the spectrogram for pitch'''
+    
+    #direclt use URL and convert to audio file
+    audio, samplerate = sf.read(io.BytesIO(urlopen(url).read()))
+    
+    audio = audio.T
+    data_22k = librosa.resample(audio, samplerate, 21395) # local files: sampleRate = 22050
+    fig = plt.figure(figsize=[1.5,10])
+
+    # Convert audio array to 'Constant-Q transform'. 86 bins are created to take pitches form E1 to C#8
+    conQfit = librosa.cqt(data_22k,hop_length=4096,n_bins=86)
+    librosa.display.specshow(conQfit)
+               
+    # Capture image and convert into 2D array
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=(56))
+    buf.seek(0)
+    data = buf.read()
+    buf.close()
+    
+    return data
+
+def get_spect_inst(url):
+    '''This function get the spectrogram for instrument'''
+
+    #URL 
+    audio, samplerate = sf.read(io.BytesIO(urlopen(url).read()))
+
+    audio = audio.T
+    data_22k = librosa.resample(audio, samplerate, 21395)
+
+    fig = plt.figure(figsize=[6,4])
+
+    # Convert audio array to 'Constant-Q transform'. 86 bins are created to take pitches form E1 to C#8
+    mfccs = librosa.feature.melspectrogram(data_22k, hop_length = 1024)  
+    mel_spec = librosa.power_to_db(mfccs, ref=np.max,)
+    librosa.display.specshow(mel_spec)
+
+    # Capture image and convert into 2D array
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=(90))
+    buf.seek(0)
+    data = buf.read()
+    buf.close()
+    
+    
+    return data 
+
+

--- a/app.py
+++ b/app.py
@@ -3,8 +3,11 @@ from flask import Flask, render_template, request
 from werkzeug.utils import secure_filename
 
 import URLtest_predict_pipeline
+import Getting_spectrogram
 import cloudinary
 import cloudinary.uploader
+import matplotlib
+matplotlib.use('Agg')
 
 
 
@@ -34,17 +37,24 @@ def upload_file():
          
          #f.save(secure_filename(f.filename))
          #file_name = (f.filename)
-         #result = cloudinary.uploader.unsigned_upload(f, upload_preset= 'q8vijdwg', cloud_name = 'dmqj5ypfp', resource_type='auto' )
-         results = cloudinary.uploader.upload(f, api_key ='985558713519965', api_secret = 'oE0lsB5Y-h5nJZbzlphcWgVBMhY', cloud_name = 'lulu666666', resource_type = 'video', use_filename = True, unique_filename= False)
-         wavURL = results['url']
+         result = cloudinary.uploader.unsigned_upload(f, upload_preset= 'q8vijdwg', cloud_name = 'dmqj5ypfp', resource_type='auto' )
+         #results = cloudinary.uploader.upload(f, api_key ='985558713519965', api_secret = 'oE0lsB5Y-h5nJZbzlphcWgVBMhY', cloud_name = 'lulu666666', resource_type = 'video', use_filename = True, unique_filename= False)
+         wavURL = result['url']
          predicted_pitch = URLtest_predict_pipeline.predict_pitch(wavURL)
          predicted_inst = URLtest_predict_pipeline.predict_instrument(wavURL)
+         spect_p = Getting_spectrogram.get_spect_pitch(wavURL)
+         spect_i = Getting_spectrogram.get_spect_inst(wavURL)
+         img_p = cloudinary.uploader.unsigned_upload(spect_p, upload_preset= 'p74xgs7f', cloud_name = 'dmqj5ypfp', resource_type='auto' )
+         img_i = cloudinary.uploader.unsigned_upload(spect_i, upload_preset= 'p74xgs7f', cloud_name = 'dmqj5ypfp', resource_type='auto' )
+         image_p = img_p['url']
+         image_i = img_i['url']
          version = wavURL
+         
 
          #testing 
          #predicted_pitch = 'A3'
          #predicted_inst = 'Piano'
-         return render_template('dashboard.html', predicted_pitch = predicted_pitch, predicted_inst = predicted_inst, version = version) 
+         return render_template('dashboard.html', predicted_pitch = predicted_pitch, predicted_inst = predicted_inst, version = version, image_p = image_p, image_i = image_i) 
       
       else: 
          #return "file type error"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -39,8 +39,10 @@
         <img src = "https://i.imgur.com/gTQexaO.png"/>
         <hr/>
 
-        <h2> Spectrogram image</h2>
-        <img src = "https://upload.wikimedia.org/wikipedia/commons/c/c5/Spectrogram-19thC.png" />
+        <h2> Pitch Spectrogram image</h2>
+        <img src = "{{ image_p }}" />
+        <h2> Instrument Spectrogram image</h2>
+        <img src = "{{ image_i }}" />
         <hr/>
            
            


### PR DESCRIPTION
I added Getting_spectrogam.py file where it has functions that returns the spectrogram for both the instrument and pitch.

Updated the app.py to store the spectrograms in cloudinary and then show it in our dashboard.

Thank you!